### PR TITLE
Propagate exceptions from `ThreadPoolExecutor`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ python = "^3.9"
 elasticsearch = "^8.6.1"
 environs = "^9.5.0"
 psycopg = "^3.1.8"
+pytest-mock = "^3.10.0"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^6.0.0"

--- a/src/sinker/runner.py
+++ b/src/sinker/runner.py
@@ -1,3 +1,4 @@
+import concurrent
 import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
@@ -41,8 +42,12 @@ class Runner:
 
         # set up materialized views and Elasticsearch indices, and populate them with initial data
         with ThreadPoolExecutor(max_workers=len(self.views_to_sinkers)) as executor:
+            futures = []
             for sinker in self.views_to_sinkers.values():
-                executor.submit(sinker.setup)
+                futures.append(executor.submit(sinker.setup))
+            for future in concurrent.futures.as_completed(futures):
+                view: str = future.result()
+                logger.info(f"{view} sinker is set up")
 
         parent_tables_to_indices: dict[str, str] = {
             sinker.parent_table: sinker.index for sinker in self.views_to_sinkers.values()
@@ -84,11 +89,14 @@ class Runner:
             sleep(SINKER_POLL_INTERVAL)
             return
         with ThreadPoolExecutor(max_workers=len(views)) as executor:
+            futures = []
             for view_tuple in views:
                 view: str = view_tuple[0].split(SCHEMA_TABLE_DELIMITER)[1]
                 sinker: Sinker = self.views_to_sinkers[view]
-                executor.submit(sinker.refresh_view)
-                logger.debug(f"{view} view is refreshed")
+                futures.append(executor.submit(sinker.refresh_view))
+            for future in concurrent.futures.as_completed(futures):
+                view: str = future.result()
+                logger.info(f"{view} view is refreshed")
 
         # ---------------------------------------
         # a triggered update from here on will cause a new materialized view entry to be added to the "end"

--- a/src/sinker/runner.py
+++ b/src/sinker/runner.py
@@ -95,8 +95,8 @@ class Runner:
                 sinker: Sinker = self.views_to_sinkers[view]
                 futures.append(executor.submit(sinker.refresh_view))
             for future in concurrent.futures.as_completed(futures):
-                view: str = future.result()
-                logger.info(f"{view} view is refreshed")
+                view_result: str = future.result()
+                logger.info(f"{view_result} view is refreshed")
 
         # ---------------------------------------
         # a triggered update from here on will cause a new materialized view entry to be added to the "end"

--- a/src/sinker/sinker.py
+++ b/src/sinker/sinker.py
@@ -35,12 +35,13 @@ class Sinker:
         self.index: str = index
         self.parent_table: str = ""  # defined during setup process
 
-    def setup(self):
+    def setup(self) -> str:
         """
         Creates materialized views with supporting functions and triggers, and creates Elasticsearch indices
         """
         self.setup_pg()
         self.setup_es()
+        return self.view
 
     def setup_es(self) -> None:
         logger.info(f"Setting up the {self.index} Elasticsearch index")
@@ -127,7 +128,8 @@ class Sinker:
         # 0/24EF4718,17394,COMMIT 17394
         self.parent_table = schema_tables[-1]
 
-    def refresh_view(self) -> None:
+    def refresh_view(self) -> str:
         logger.info(f"Refreshing the {self.view} materialized view")
         refresh_view_query: str = q.REFRESH_VIEW.format(SINKER_SCHEMA, self.view)
         psycopg.connect(autocommit=True).execute(refresh_view_query)
+        return self.view


### PR DESCRIPTION
Non-recoverable errors (e.g., missing materialized view) in thread tasks setup() and refresh_view() should bubble up to the application and cause it to exit.