### PR TITLE
chore: fix incorrect .execute() call on psycopg.Connection

### DIFF
--- a/src/sinker/runner.py
+++ b/src/sinker/runner.py
@@ -35,7 +35,9 @@ class Runner:
             q.DROP_TODO_TABLE.format(SINKER_SCHEMA, SINKER_TODO_TABLE),
             q.CREATE_TODO_TABLE.format(SINKER_SCHEMA, SINKER_TODO_TABLE),
         ]
-        psycopg.connect(autocommit=True).execute("; ".join(ddl_list))
+        with psycopg.connect(autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute("; ".join(ddl_list))
         self.views_to_sinkers: dict[str, Sinker] = {
             view: Sinker(view, index) for (view, index) in views_to_indices.items()
         }


### PR DESCRIPTION
While reviewing the code, I noticed a mistake in the following line:  

```python
psycopg.connect(autocommit=True).execute("; ".join(ddl_list))
```  

The issue is that `psycopg.connect(autocommit=True)` returns a `Connection` object, but `.execute()` is not a method of `Connection`. Instead, queries must be executed via a `Cursor`, obtained using `.cursor()`.  

### **Fix:**  
The corrected version properly creates a cursor and executes the query:  

```python
with psycopg.connect(autocommit=True) as conn:
    with conn.cursor() as cur:
        cur.execute("; ".join(ddl_list))
```

Now, the code correctly initializes the connection, retrieves a cursor, and executes the SQL statement.
This ensures proper database interaction and avoids potential `AttributeError`.